### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ To see how easy it is to get a build running with [Cake](https://github.com/cake
 * Run this powershell  to get the 2 files required to bootstrap the build:
 	```PowerShell
 
-	"build.ps1","build.cake"|%{Invoke-RestMethod -Uri "https://raw.githubusercontent.com/cake-build/bootstrapper/master/res/scripts/$($_)" -OutFile $_}
+	Invoke-RestMethod -Uri "https://raw.githubusercontent.com/cake-build/resources/develop/build.ps1" > build.ps1
+	Invoke-RestMethod -Uri "https://raw.githubusercontent.com/cake-build/bootstrapper/master/res/scripts/build.cake" > build.cake
+
 	```
 * Run the PS script ./Build.ps1
 


### PR DESCRIPTION
The legacy build.ps1 script references an old location for the tools\packages.config file, and will fail on any machine that does not already have that file downloaded. (i.e. a build server) 

Updating this readme with the latest location for the build.ps1 file (from the cake-build/resources repo, rather than the deprecated bootstrapper repo) which references the correct location.