### PR TITLE
Fix formatting and some typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-#TL;DR
-To see how easy it is to get a build running with [Cake](https://github.com/cake-build/cake)
+# TL;DR
+
+To see how easy it is to get a build running with [Cake](https://github.com/cake-build/cake):
 
 * Clone this repo (which has no Cake files)
 
-* Run this powershell  to get the 2 files required to bootstrap the build:
+* Run this PowerShell to get the 2 files required to bootstrap the build:
 	```PowerShell
 
 	"build.ps1","build.cake"|%{Invoke-RestMethod -Uri "https://raw.githubusercontent.com/cake-build/bootstrapper/master/res/scripts/$($_)" -OutFile $_}
 	```
-* Run the PS script ./Build.ps1
+* Run the PS script `./Build.ps1`
 
+Note, you don't *have* to use PowerShell to use Cake. I just love that I can add 2 small files to my repo and that's all I need for the build process to work.
 
-Note, you don't *have* to use powershell to use Cake. I just love that I can add 2 small files to my repo and that's all I need for the build process to work.
-
-#The slightly longer version
+# The slightly longer version
 
 Here's some info about [Cake](https://github.com/cake-build/cake):
 
@@ -28,43 +28,55 @@ Cake (C# Make) is a build automation system with a C# DSL to do things like comp
 
 [![Join the chat at https://gitter.im/cake-build/cake](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/cake-build/cake?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-##So what's this Repo?
+## So what's this repo?
 
 I have just started using Cake and it took me a little (not long) time to figure out what I needed to start my build process. It turns out that it's hardly anything and the steps are simple. This is my attempt to document that.
 
-This repo has a very simple Hello World C# Console solution with a Nuget dependency (log4net). It has *no* build scripts or *any* Cake-related files.
+This repo has a very simple Hello World C# Console solution with a NuGet dependency (log4net). It has *no* build scripts or *any* Cake-related files.
 
-By following these steps you can have it building with Cake in a few minutes
+By following these steps you can have it building with Cake in a few minutes.
 
-###1. Clone this repo 
+### 1. Clone this repo 
+
 if you haven't already.
-###2. Get the required files
-You need 2 files for a build (these will all you'll have to commit to you repo to use Cake):
-* build.ps1
-  * This is a bootstrapper powershell script that ensures you have Cake and required dependencies installed.
-* build.cake
-  * This is the actual build script. It doesn't have to be named this but this will be found by default.
 
-An easy way to get these files is to download them using powershell. 
-Open powershell, CD to the root of your repo and execute this command (this will not execute the powershell script, just download it):
+### 2. Get the required files
+
+You need 2 files for a build (these are all you'll have to commit to your repo to use Cake):
+
+* `build.ps1`  
+  This is a bootstrapper PowerShell script that ensures you have Cake and required dependencies installed.
+  
+* `build.cake`  
+  This is the actual build script. It doesn't have to be named this but this will be found by default.
+
+An easy way to get these files is to download them using PowerShell.
+Open PowerShell, CD to the root of your repo and execute this command (this will not execute the PowerShell script, just download it):
+
 ```PowerShell
 "build.ps1","build.cake"|%{Invoke-RestMethod -Uri "https://raw.githubusercontent.com/cake-build/bootstrapper/master/res/scripts/$($_)" -OutFile $_}
 ```
-This downloads the files from [Cake Bootstrapper](https://github.com/cake-build/bootstrapper)
-Other ways to get the files can be found on the [Getting Started](http://cakebuild.net/getting-started/) page on [cakebuild.net](http://cakebuild.net)
-###3. Run the build script
-Still in powershell execute the script. 
+
+This downloads the files from [Cake Bootstrapper](https://github.com/cake-build/bootstrapper).
+Other ways to get the files can be found on the [Getting Started](http://cakebuild.net/getting-started/) page on [cakebuild.net](http://cakebuild.net).
+
+### 3. Run the build script
+
+Still in PowerShell execute the script. 
+
 ```PowerShell
 .\build.ps1
 ```
 
-The script will detect that you don't have cake and download it. It will then run the very simple build.cake script that finds any .sln in files in or below the current folder, restores any NuGet dependencies, and builds them.
+The script will detect that you don't have Cake and download it. It will then run the very simple `build.cake` script that finds any `.sln` in files in or below the current folder, restores any NuGet dependencies, and builds them.
 
 
 Congratulations, you've run you first Cake script!
 
-###4. Bonus points! - run the tests
+### 4. Bonus points! - run the tests
+
 The script is a fairly bare-bones implementation. But extending it is easy. For instance to run the extensive unit tests for the awesome application you need to add a test target:
+
 ```CSharp
 Task("Run-Unit-Tests")
     .IsDependentOn("Build")
@@ -73,16 +85,20 @@ Task("Run-Unit-Tests")
     MSTest("./src/**/bin/" + configuration + "/*Test.dll");
 });
 ```
-This is using MSTest but out of the box you have XUnit and NUnit test helpers as well.
+
+This is using MSTest but out of the box you have xUnit and NUnit test helpers as well.
 
 Adding the target doesn't necessarily run it unless another target is dependent on it or you call it explicitly.
 
 In our case we can just change the default task to be dependent on our test task (which in turn is dependent on the build task):
+
 ```CSharp
 Task("Default")
     .IsDependentOn("Run-Unit-Tests");
 ```
-Running the build now will run the tests after building...
+
+Running the build now will run the tests after building.
+
 ```PowerShell
 .\build.ps1
 ```


### PR DESCRIPTION
This encompasses mostly the following changes:

* Headings don't render properly if `#` isn't followed by a whitespace.
* `powershell` -> `PowerShell`

See it rendered: [proposed changes](https://github.com/stakx/Cake-Example/blob/e61507d9f78c6a1c2068aa7cc55488a416ce13b8/README.md) vs. [current](https://github.com/marcosnz/Cake-Example/blob/db63c35aad17a4378a17d86fb5f88b06be4ea7fc/README.md).